### PR TITLE
#18: Improve quickestLevelUp and fastestFame

### DIFF
--- a/src/buildWorkshop/computeIdealLevelsForEvent.ts
+++ b/src/buildWorkshop/computeIdealLevelsForEvent.ts
@@ -65,7 +65,7 @@ export function quickestNewLevel(partialWorkshopStatus: Partial<WorkshopStatus>)
     console.log(`testing multiple resets at ${fame} fame each...`);
     const target = computeTargetFromFame(fame, workshopStatus.level);
     const targetInfo = bottomUpToMoney(target, workshopStatus);
-    const idleBuildTime = targetInfo.cyclesToTarget;
+    const idleBuildTime = computeBuildTimeForWorkshop(targetInfo.workshop, target);
     // const researchTime = computeResearchTimeForWorkshop(targetInfo.workshop);
     const finalTime = (idleBuildTime + 10) * Math.ceil(fameRequiredToLevelUp / fame);
     if (finalTime < bestTime) {
@@ -89,13 +89,14 @@ export function fastestFamePerSecond(partialWorkshopStatus: Partial<WorkshopStat
     console.log(`testing multiple resets at ${fame} fame each...`);
     const target = computeTargetFromFame(fame, workshopStatus.level);
     const targetInfo = bottomUpToMoney(target, workshopStatus);
-    const idleBuildTime = targetInfo.cyclesToTarget + 10 * Math.ceil(fameRequiredToLevelUp / fame);
-    console.log(`${fame} fame takes ${toTime(idleBuildTime)}`);
-    if (idleBuildTime > 60 * 45) {
+    const buildTime = computeBuildTimeForWorkshop(targetInfo.workshop, target);
+    const resetTime = buildTime + 10 * Math.ceil(fameRequiredToLevelUp / fame);
+    console.log(`${fame} fame takes ${toTime(resetTime)}`);
+    if (resetTime > 60 * 45) {
       console.log(`${fame} fame takes too long`);
       break;
     }
-    const timePerFame = idleBuildTime / fame;
+    const timePerFame = resetTime / fame;
     if (timePerFame < bestTime) {
       bestTime = timePerFame;
       bestFame = fame;

--- a/src/buildWorkshop/computeIdealLevelsForEvent.ts
+++ b/src/buildWorkshop/computeIdealLevelsForEvent.ts
@@ -1,6 +1,6 @@
 import { isEvent } from './helpers/WorkshopHelpers';
 import { toTime } from './helpers/printResults';
-import { computeTargetFromFame } from './helpers/targetHelpers';
+import { computeBuildTimeForWorkshop, computeTargetFromFame } from './helpers/targetHelpers';
 import { importProductsAtLevel } from './importEventProducts';
 import { importMainWorkshop } from './importMainWorkshop';
 import { bottomUpBuilder, topDownLeveler } from './productLooper';
@@ -61,13 +61,17 @@ export function quickestNewLevel(partialWorkshopStatus: Partial<WorkshopStatus>)
   let bestTime = Number.MAX_VALUE;
   let bestFame = fameRequiredToLevelUp;
   let bestWorkshopUpgrade;
-  for (let fame = 2; fame < Math.min(fameRequiredToLevelUp, 13); fame++) {
+  for (let fame = isEvent(workshopStatus) ? 1 : 12; fame < Math.min(fameRequiredToLevelUp, 30); fame++) {
     console.log(`testing multiple resets at ${fame} fame each...`);
     const target = computeTargetFromFame(fame, workshopStatus.level);
     const targetInfo = bottomUpToMoney(target, workshopStatus);
     const idleBuildTime = computeBuildTimeForWorkshop(targetInfo.workshop, target);
     // const researchTime = computeResearchTimeForWorkshop(targetInfo.workshop);
     const finalTime = (idleBuildTime + 10) * Math.ceil(fameRequiredToLevelUp / fame);
+    if (finalTime > 60 * 45) {
+      console.log(`${fame} fame takes too long`);
+      break;
+    }
     if (finalTime < bestTime) {
       bestTime = finalTime;
       bestFame = fame;
@@ -85,7 +89,7 @@ export function fastestFamePerSecond(partialWorkshopStatus: Partial<WorkshopStat
   let bestTime = Number.MAX_VALUE;
   let bestFame = fameRequiredToLevelUp;
   let bestWorkshopUpgrade;
-  for (let fame = 2; fame < Math.min(fameRequiredToLevelUp, 30); fame++) {
+  for (let fame = 12; fame < Math.min(fameRequiredToLevelUp, 30); fame++) {
     console.log(`testing multiple resets at ${fame} fame each...`);
     const target = computeTargetFromFame(fame, workshopStatus.level);
     const targetInfo = bottomUpToMoney(target, workshopStatus);

--- a/src/buildWorkshop/productLooper.ts
+++ b/src/buildWorkshop/productLooper.ts
@@ -39,7 +39,21 @@ export function bottomUpBuilder(target: number, workshop: Workshop): WorkshopUpg
   const firstPassBuildTime = computeBuildTimeForWorkshop(firstPassOptimizedWorkshop, target);
 
   console.info('trimming unneeded products...');
-  return trimWorkshop(target, workshop, firstPassOptimizedWorkshop, firstPassBuildTime);
+  const trimmedWorkshop = trimWorkshop(target, firstPassOptimizedWorkshop, firstPassBuildTime);
+
+  for (
+    let finalProductBuilt = trimmedWorkshop.workshop.productsInfo.length - 1;
+    finalProductBuilt >= 0;
+    finalProductBuilt--
+  ) {
+    const finalProduct: Product | undefined = trimmedWorkshop.workshop.productsInfo[finalProductBuilt];
+    if (finalProduct.status.level > 0) {
+      const modifiedWorkshopInfo = topDownLeveler(target, finalProduct.details.name, trimmedWorkshop.workshop, 1);
+      return modifiedWorkshopInfo;
+    }
+  }
+
+  return trimmedWorkshop;
 }
 
 function getFirstPassOptimizedWorkshop(workshop: Workshop, target: number): Workshop {
@@ -59,13 +73,8 @@ function getFirstPassOptimizedWorkshop(workshop: Workshop, target: number): Work
   return modifiedWorkshop;
 }
 
-function trimWorkshop(
-  target: number,
-  workshop: Workshop,
-  bestWorkshop: Workshop,
-  bestBuildTime: number,
-): WorkshopUpgradeInfo {
-  for (let productIndex = workshop.productsInfo.length - 1; productIndex > 0; productIndex--) {
+function trimWorkshop(target: number, bestWorkshop: Workshop, bestBuildTime: number): WorkshopUpgradeInfo {
+  for (let productIndex = bestWorkshop.productsInfo.length - 1; productIndex > 0; productIndex--) {
     const product = bestWorkshop.productsInfo[productIndex];
     if (product.status.level > 0 && isProductLeaf(product.details.name, bestWorkshop)) {
       const workshopWithProductZeroed = getWorkshopWithProductLevelAsZero(product, bestWorkshop);

--- a/src/upgradeBlueprints/config/BlueprintLibrary.ts
+++ b/src/upgradeBlueprints/config/BlueprintLibrary.ts
@@ -15,6 +15,13 @@ const s51 = {
   b4: { ...BASE_BP, evolutionStage: 4, score: 26880, scoreChangePerLevel: 2688 },
 };
 
+// strategy 71+10
+const s71 = {
+  b2: { ...BASE_BP, evolutionStage: 2, score: 160, scoreChangePerLevel: 16 },
+  b3: { ...BASE_BP, evolutionStage: 3, score: 2880, scoreChangePerLevel: 288 },
+  b4: { ...BASE_BP, evolutionStage: 4, score: 57600, scoreChangePerLevel: 5760 },
+};
+
 export const BLUEPRINT_LIBRARY: Blueprint[] = [
   { ...s51.b4, productName: 'Wood', upgradeLevel: 71, score: 215040 },
   { ...s21.b2, productName: 'Club' },
@@ -71,17 +78,17 @@ export const BLUEPRINT_LIBRARY: Blueprint[] = [
   { ...BASE_BP, productName: 'Magnificent Sword' },
   { ...BASE_BP, productName: 'Uncut Sapphire', upgradeLevel: 21, score: 30 },
   { ...BASE_BP, productName: 'Magnificent Armor' },
-  { ...s51.b2, productName: 'Mechanical Parts', upgradeLevel: 31, score: 480 },
+  { ...s51.b2, productName: 'Mechanical Parts', upgradeLevel: 41, score: 600 },
   { ...BASE_BP, productName: 'Magnificent Crossbow', upgradeLevel: 31, score: 40 },
   { ...BASE_BP, productName: 'Sulfur', upgradeLevel: 31, score: 40 },
   { ...BASE_BP, productName: 'Bongos', upgradeLevel: 41, score: 50 },
   { ...BASE_BP, productName: 'Cut Sapphire' },
   { ...BASE_BP, productName: 'Microscope', upgradeLevel: 21, score: 30 },
-  { ...BASE_BP, productName: 'Compass', upgradeLevel: 61, score: 70 },
+  { ...s71.b2, productName: 'Compass', upgradeLevel: 41, score: 800 },
   { ...BASE_BP, productName: 'Clockwork', upgradeLevel: 21, score: 30 },
   { ...BASE_BP, productName: 'Saltpeter', upgradeLevel: 31, score: 40 },
   { ...BASE_BP, productName: 'Gunpowder', upgradeLevel: 41, score: 50 },
-  { ...BASE_BP, productName: 'Saxophone', upgradeLevel: 41, score: 50 },
+  { ...s51.b2, productName: 'Saxophone', upgradeLevel: 21, score: 360 },
   { ...BASE_BP, productName: 'Electro Magnet', upgradeLevel: 21, score: 30 },
   { ...BASE_BP, productName: 'Machine Parts', upgradeLevel: 21, score: 30 },
   { ...BASE_BP, productName: 'Camera', upgradeLevel: 21, score: 30 },
@@ -125,14 +132,30 @@ export const BUILD_COST_OF_BPS_WITHOUT_DETAILS = new Map<string, number>([
 ]);
 
 // TODO: GH-4: only merge if there are excess blueprints for that product. for now, hardcode ones the algo wants that i don't have
+const BPS_WITHOUT_DUPES = [
+  'Chisel',
+  'Map',
+  'Bongos',
+  'Copper Dagger',
+  // 'Copper Blades',
+  'Copper Knife',
+  'Bronze Spear',
+  'Bronze Shield',
+  'Bronze Blades',
+  'Bronze Dagger',
+  'Wood',
+  // 'Club',
+  'Arrows',
+  'Bow',
+];
 // TODO: set up the strategy to also allow marking a top tier at which to stop merging. for now put that here
-const BPS_WITHOUT_DUPES = ['Chisel', 'Map', 'Bongos', 'Copper Dagger', 'Copper Blades', 'Copper Knife'];
 const BPS_AT_TOP = ['Copper Axe'];
 export const BPS_TO_NOT_MERGE = [...BPS_WITHOUT_DUPES, ...BPS_AT_TOP];
 
 // some blueprints should not use 51+10 strategy. they should use x+10 instead, map product name to x
 export const NON_51_PLUS_10_STRATEGY = new Map<string, number>([
   ['Compass', 71],
+  ['Light Bulb', 71],
   ['Club', 21],
   ['Arrows', 21],
   ['Bow', 21],

--- a/test/buildWorkshop/runProgram.not.test.ts
+++ b/test/buildWorkshop/runProgram.not.test.ts
@@ -2,6 +2,7 @@ import {
   bestGemChance,
   bottomUpToLastItem,
   bottomUpToMoney,
+  fastestFamePerSecond,
   productDownUpToMoney,
   quickestNewLevel,
 } from '../../src/buildWorkshop/computeIdealLevelsForEvent';
@@ -299,6 +300,10 @@ describe.only('runProgram', () => {
 
       test('20 fame lvl 43', () => {
         printFameTime(20, { level: 43, scientists: 1001, researchBoostActive: true });
+      });
+
+      test('19 fame lvl 54', () => {
+        printFameTime(19, { level: 54, scientists: 1144, researchBoostActive: true, speedBoostActive: true });
       });
     });
 
@@ -655,6 +660,27 @@ describe.only('runProgram', () => {
           speedBoostActive: true,
           merchantBoostActive: true,
           researchBoostActive: true,
+        });
+      });
+    });
+
+    describe('fastest fame', () => {
+      function fastestFame(partialWorkshopStatus: Partial<WorkshopStatus>): void {
+        const moreWorkshopStatus = {
+          clickBoostActive: false,
+          researchBoostActive: true,
+          merchantBoostActive: false,
+          ...partialWorkshopStatus,
+        };
+        const targetInfo = fastestFamePerSecond(moreWorkshopStatus);
+        printInfo(targetInfo);
+      }
+
+      it('lvl 40', () => {
+        fastestFame({
+          level: 40,
+          scientists: 935,
+          speedBoostActive: true,
         });
       });
     });


### PR DESCRIPTION
Compute build time more accurately, set better min and max fame values, and adjust the last product to always relate to the target.