### PR TITLE
#18: Clean up cyclesToTarget

### DIFF
--- a/src/buildWorkshop/computeIdealLevelsForEvent.ts
+++ b/src/buildWorkshop/computeIdealLevelsForEvent.ts
@@ -3,7 +3,7 @@ import { toTime } from './helpers/printResults';
 import { computeBuildTimeForWorkshop, computeTargetFromFame } from './helpers/targetHelpers';
 import { importProductsAtLevel } from './importEventProducts';
 import { importMainWorkshop } from './importMainWorkshop';
-import { WorkshopUpgradeInfo, bottomUpBuilder } from './productLooper';
+import { WorkshopUpgradeInfo, buildWorkshopToTarget } from './productLooper';
 import { Product, ProductDetails } from './types/Product';
 import {
   DEFAULT_WORKSHOP_STATUS_EVENT,
@@ -14,7 +14,7 @@ import {
 
 export function bottomUpToLastItem(partialWorkshopStatus: Partial<WorkshopStatus>): WorkshopUpgradeInfo {
   const workshop: Workshop = setUpWorkshop(partialWorkshopStatus);
-  return bottomUpBuilder(workshop.productsInfo[workshop.productsInfo.length - 1].details.buildCost, workshop);
+  return buildWorkshopToTarget(workshop.productsInfo[workshop.productsInfo.length - 1].details.buildCost, workshop);
 }
 
 export function quickestNewLevel(partialWorkshopStatus: Partial<WorkshopStatus>): WorkshopUpgradeInfo {
@@ -95,7 +95,7 @@ export function bestGemChance(partialWorkshopStatus: Partial<WorkshopStatus>): {
 
 export function bottomUpToMoney(target: number, partialWorkshopStatus: Partial<WorkshopStatus>): WorkshopUpgradeInfo {
   const workshop: Workshop = setUpWorkshop(partialWorkshopStatus);
-  return bottomUpBuilder(target, workshop);
+  return buildWorkshopToTarget(target, workshop);
 }
 
 function setUpWorkshop(partialWorkshopStatus: Partial<WorkshopStatus>): Workshop {

--- a/src/buildWorkshop/computeIdealLevelsForEvent.ts
+++ b/src/buildWorkshop/computeIdealLevelsForEvent.ts
@@ -3,8 +3,7 @@ import { toTime } from './helpers/printResults';
 import { computeBuildTimeForWorkshop, computeTargetFromFame } from './helpers/targetHelpers';
 import { importProductsAtLevel } from './importEventProducts';
 import { importMainWorkshop } from './importMainWorkshop';
-import { bottomUpBuilder, topDownLeveler } from './productLooper';
-import { WorkshopUpgradeInfo } from './shouldUpgrade';
+import { WorkshopUpgradeInfo, bottomUpBuilder } from './productLooper';
 import { Product, ProductDetails } from './types/Product';
 import {
   DEFAULT_WORKSHOP_STATUS_EVENT,
@@ -12,43 +11,6 @@ import {
   Workshop,
   WorkshopStatus,
 } from './types/Workshop';
-
-export function topDownToLastItem(partialWorkshopStatus: Partial<WorkshopStatus>): WorkshopUpgradeInfo {
-  const workshop: Workshop = setUpWorkshop(partialWorkshopStatus);
-  return topDownLeveler(
-    workshop.productsInfo[workshop.productsInfo.length - 1].details.buildCost,
-    workshop.productsInfo[workshop.productsInfo.length - 2].details.name,
-    workshop,
-  );
-}
-
-export function productDownUpToMoney(
-  partialWorkshopStatus: Partial<WorkshopStatus>,
-  target: number,
-  productName: string,
-): WorkshopUpgradeInfo {
-  const workshop: Workshop = setUpWorkshop(partialWorkshopStatus);
-  return topDownLeveler(target, productName, workshop);
-}
-
-// for when you have a full workshop and want to build the single next thing without optimizing the whole path up
-// currently looks at the exact previous item
-export function topDownToTargetProduct(
-  partialWorkshopStatus: Partial<WorkshopStatus>,
-  productName: string,
-): WorkshopUpgradeInfo {
-  const workshop: Workshop = setUpWorkshop(partialWorkshopStatus);
-  let productBeforeTarget: string = workshop.productsInfo[0].details.name;
-  for (const product of workshop.productsInfo) {
-    if (product.details.name === productName) {
-      return topDownLeveler(product.details.buildCost, productBeforeTarget, workshop);
-    } else {
-      productBeforeTarget = product.details.name;
-    }
-  }
-
-  throw new Error('cannot find product ' + productName + ' in workshop ' + JSON.stringify(workshop.productsInfo));
-}
 
 export function bottomUpToLastItem(partialWorkshopStatus: Partial<WorkshopStatus>): WorkshopUpgradeInfo {
   const workshop: Workshop = setUpWorkshop(partialWorkshopStatus);
@@ -119,11 +81,11 @@ export function bestGemChance(partialWorkshopStatus: Partial<WorkshopStatus>): {
   console.info('computing time to reach 14 fame...');
   const workshopStatus: WorkshopStatus = { ...DEFAULT_WORKSHOP_STATUS_MAIN, ...partialWorkshopStatus };
   const targetInfo14 = bottomUpToMoney(computeTargetFromFame(14, workshopStatus.level), workshopStatus);
-  const timePerGemChance14 = targetInfo14.cyclesToTarget / 8;
+  const timePerGemChance14 = targetInfo14.buildTime / 8;
 
   console.info('computing time to reach 15 fame...');
   const targetInfo15 = bottomUpToMoney(computeTargetFromFame(15, workshopStatus.level), workshopStatus);
-  const timePerGemChance15 = targetInfo15.cyclesToTarget / 12;
+  const timePerGemChance15 = targetInfo15.buildTime / 12;
 
   console.log(`best gem chance per time at ${timePerGemChance14 < timePerGemChance15 ? 14 : 15}`);
   return timePerGemChance14 < timePerGemChance15

--- a/src/buildWorkshop/helpers/printResults.ts
+++ b/src/buildWorkshop/helpers/printResults.ts
@@ -1,5 +1,5 @@
 import { bottomUpToMoney } from '../computeIdealLevelsForEvent';
-import { WorkshopUpgradeInfo } from '../shouldUpgrade';
+import { WorkshopUpgradeInfo } from '../productLooper';
 import { DEFAULT_WORKSHOP_STATUS_MAIN, Workshop, WorkshopStatus } from '../types/Workshop';
 import { computeResearchTimeForWorkshop, getFinalNumScientistsCanAfford } from './ResearchHelpers';
 import { getStatusMap } from './WorkshopHelpers';

--- a/src/buildWorkshop/productLooper.ts
+++ b/src/buildWorkshop/productLooper.ts
@@ -3,21 +3,11 @@ import { getProductsInfoWithNewStatusForProduct, getUpgradedWorkshopIfBetter } f
 import { Product, ProductStatus } from './types/Product';
 import { Workshop } from './types/Workshop';
 
-export function topDownLeveler(
-  target: number,
-  productName: string,
-  workshop: Workshop,
-  skipBuildIfUnderXCycles: number = 60,
-): Workshop {
+export function topDownLeveler(target: number, productName: string, workshop: Workshop): Workshop {
   let shouldUpgradeNext = true;
   let modifiedWorkshop: Workshop = workshop;
   while (shouldUpgradeNext) {
-    const upgradedWorkshop: Workshop | null = getUpgradedWorkshopIfBetter(
-      target,
-      productName,
-      modifiedWorkshop,
-      skipBuildIfUnderXCycles,
-    );
+    const upgradedWorkshop: Workshop | null = getUpgradedWorkshopIfBetter(target, productName, modifiedWorkshop);
     shouldUpgradeNext = upgradedWorkshop !== null;
     if (upgradedWorkshop != null) {
       modifiedWorkshop = upgradedWorkshop;
@@ -49,7 +39,7 @@ function getFirstPassOptimizedWorkshop(workshop: Workshop, target: number): Work
     const nextProduct: Product | undefined = workshop.productsInfo[productIndex + 1];
     if (thisProduct !== undefined) {
       const currentTarget = nextProduct !== undefined ? Math.min(target, nextProduct.details.buildCost) : target;
-      modifiedWorkshop = topDownLeveler(currentTarget, thisProduct.details.name, modifiedWorkshop, 1);
+      modifiedWorkshop = topDownLeveler(currentTarget, thisProduct.details.name, modifiedWorkshop);
       if (nextProduct === undefined || target < nextProduct.details.buildCost) {
         break;
       }
@@ -77,7 +67,7 @@ function trimWorkshop(target: number, untrimmedWorkshop: Workshop, bestBuildTime
   if (lastProduct === undefined) {
     throw new Error('no products build in workshop');
   }
-  bestWorkshop = topDownLeveler(target, lastProduct.details.name, bestWorkshop, 1);
+  bestWorkshop = topDownLeveler(target, lastProduct.details.name, bestWorkshop);
   const buildTime = computeBuildTimeForWorkshop(bestWorkshop, target);
 
   return {

--- a/src/buildWorkshop/productLooper.ts
+++ b/src/buildWorkshop/productLooper.ts
@@ -39,18 +39,6 @@ export function bottomUpBuilder(target: number, workshop: Workshop): WorkshopUpg
   console.info('trimming unneeded products...');
   const trimmedWorkshop = trimWorkshop(target, firstPassOptimizedWorkshop, firstPassBuildTime);
 
-  for (
-    let finalProductBuilt = trimmedWorkshop.workshop.productsInfo.length - 1;
-    finalProductBuilt >= 0;
-    finalProductBuilt--
-  ) {
-    const finalProduct: Product | undefined = trimmedWorkshop.workshop.productsInfo[finalProductBuilt];
-    if (finalProduct.status.level > 0) {
-      const modifiedWorkshopInfo = topDownLeveler(target, finalProduct.details.name, trimmedWorkshop.workshop, 1);
-      return modifiedWorkshopInfo;
-    }
-  }
-
   return trimmedWorkshop;
 }
 
@@ -84,9 +72,17 @@ function trimWorkshop(target: number, untrimmedWorkshop: Workshop, bestBuildTime
       }
     }
   }
+
+  const lastProduct = [...bestWorkshop.productsInfo].findLast((product) => product.status.level > 0);
+  if (lastProduct === undefined) {
+    throw new Error('no products build in workshop');
+  }
+  bestWorkshop = topDownLeveler(target, lastProduct.details.name, bestWorkshop, 1);
+  const buildTime = computeBuildTimeForWorkshop(bestWorkshop, target);
+
   return {
     workshop: bestWorkshop,
-    cyclesToTarget: bestBuildTime,
+    buildTime,
   };
 }
 

--- a/src/buildWorkshop/productLooper.ts
+++ b/src/buildWorkshop/productLooper.ts
@@ -3,7 +3,7 @@ import { getProductsInfoWithNewStatusForProduct, getUpgradedWorkshopIfBetter } f
 import { Product, ProductStatus } from './types/Product';
 import { Workshop } from './types/Workshop';
 
-export function topDownLeveler(target: number, productName: string, workshop: Workshop): Workshop {
+export function levelProductToTarget(target: number, productName: string, workshop: Workshop): Workshop {
   let shouldUpgradeNext = true;
   let modifiedWorkshop: Workshop = workshop;
   while (shouldUpgradeNext) {
@@ -21,8 +21,8 @@ export type WorkshopUpgradeInfo = Readonly<{
   buildTime: number;
 }>;
 
-export function bottomUpBuilder(target: number, workshop: Workshop): WorkshopUpgradeInfo {
-  const firstPassOptimizedWorkshop = getFirstPassOptimizedWorkshop(workshop, target);
+export function buildWorkshopToTarget(target: number, workshop: Workshop): WorkshopUpgradeInfo {
+  const firstPassOptimizedWorkshop = buildProductToNextProductOfWorkshop(workshop, target);
   console.info('computing time to build optimized workshop...');
   const firstPassBuildTime = computeBuildTimeForWorkshop(firstPassOptimizedWorkshop, target);
 
@@ -32,14 +32,14 @@ export function bottomUpBuilder(target: number, workshop: Workshop): WorkshopUpg
   return trimmedWorkshop;
 }
 
-function getFirstPassOptimizedWorkshop(workshop: Workshop, target: number): Workshop {
+function buildProductToNextProductOfWorkshop(workshop: Workshop, target: number): Workshop {
   let modifiedWorkshop: Workshop = workshop;
   for (let productIndex = 0; productIndex < workshop.productsInfo.length; productIndex++) {
     const thisProduct: Product | undefined = workshop.productsInfo[productIndex];
     const nextProduct: Product | undefined = workshop.productsInfo[productIndex + 1];
     if (thisProduct !== undefined) {
       const currentTarget = nextProduct !== undefined ? Math.min(target, nextProduct.details.buildCost) : target;
-      modifiedWorkshop = topDownLeveler(currentTarget, thisProduct.details.name, modifiedWorkshop);
+      modifiedWorkshop = levelProductToTarget(currentTarget, thisProduct.details.name, modifiedWorkshop);
       if (nextProduct === undefined || target < nextProduct.details.buildCost) {
         break;
       }
@@ -48,6 +48,10 @@ function getFirstPassOptimizedWorkshop(workshop: Workshop, target: number): Work
   return modifiedWorkshop;
 }
 
+// sometimes, the first pass skips building intermediate products, ex Rawhide, because the rest of the workshop's income can get to the next product without it
+// but then, it needs a later product, ex Hilt, to get all the way up to, say, copper. so it builds Hilt and all the previous required products: leather and rawhide
+// but when building the workshop forward, if we have rawhide and leather, that takes us to copper without hilt
+// trimWorkshop removes hilt (and possibly leather) in that case, and others like it
 function trimWorkshop(target: number, untrimmedWorkshop: Workshop, bestBuildTime: number): WorkshopUpgradeInfo {
   let bestWorkshop: Workshop = untrimmedWorkshop;
   for (let productIndex = bestWorkshop.productsInfo.length - 1; productIndex > 0; productIndex--) {
@@ -67,7 +71,7 @@ function trimWorkshop(target: number, untrimmedWorkshop: Workshop, bestBuildTime
   if (lastProduct === undefined) {
     throw new Error('no products build in workshop');
   }
-  bestWorkshop = topDownLeveler(target, lastProduct.details.name, bestWorkshop);
+  bestWorkshop = levelProductToTarget(target, lastProduct.details.name, bestWorkshop);
   const buildTime = computeBuildTimeForWorkshop(bestWorkshop, target);
 
   return {

--- a/src/buildWorkshop/shouldUpgrade.ts
+++ b/src/buildWorkshop/shouldUpgrade.ts
@@ -10,25 +10,14 @@ import { getWorkshopIncomeMultiplier } from './helpers/getWorkshopIncomeMultipli
 import { Product, ProductDetails, ProductStatus } from './types/Product';
 import { Workshop, WorkshopStatus } from './types/Workshop';
 
-const scienceIsTight = true;
-
-export function getUpgradedWorkshopIfBetter(
-  target: number,
-  productName: string,
-  workshop: Workshop,
-  skipBuildIfUnderXCycles: number = 60,
-): Workshop | null {
+export function getUpgradedWorkshopIfBetter(target: number, productName: string, workshop: Workshop): Workshop | null {
   const product: Product = getProductByName(productName, workshop.productsInfo);
   const clickBoost = workshop.workshopStatus.clickBoostActive
     ? CLICK_BOOST_MULTIPLIER * PROMOTION_BONUS_CLICK_OUTPUT
     : 1;
   const incomePerCycle = getCurrentIncome(workshop, clickBoost);
   const cyclesToTarget = target / incomePerCycle;
-  if (
-    product.status.level === 0 &&
-    // product.details.input1 !== null &&
-    (scienceIsTight ? cyclesToTarget < skipBuildIfUnderXCycles : cyclesToTarget < 5)
-  ) {
+  if (product.status.level === 0 && cyclesToTarget < 1) {
     return null;
   }
 

--- a/src/buildWorkshop/shouldUpgrade.ts
+++ b/src/buildWorkshop/shouldUpgrade.ts
@@ -17,7 +17,7 @@ export function getUpgradedWorkshopIfBetter(
   productName: string,
   workshop: Workshop,
   skipBuildIfUnderXCycles: number = 60,
-): WorkshopUpgradeInfo | null {
+): Workshop | null {
   const product: Product = getProductByName(productName, workshop.productsInfo);
   const clickBoost = workshop.workshopStatus.clickBoostActive
     ? CLICK_BOOST_MULTIPLIER * PROMOTION_BONUS_CLICK_OUTPUT
@@ -37,18 +37,9 @@ export function getUpgradedWorkshopIfBetter(
   const additionalIncomePerCycle = clickBoost * getIncomeForOneLevelOfItem(product.details, workshop.workshopStatus);
   const upgradedCyclesToTarget = target / (incomePerCycle + additionalIncomePerCycle) + cyclesToRaiseUpgradeMoney;
   if (upgradedCyclesToTarget < cyclesToTarget) {
-    // console.log(`upgrading ${productName} from level ${product.status.level} in ${upgradedCyclesToTarget} cycles`);
-    return {
-      workshop: upgradeProductInfo.workshop,
-      cyclesToTarget: upgradedCyclesToTarget,
-    };
+    return upgradeProductInfo.workshop;
   } else return null;
 }
-
-export type WorkshopUpgradeInfo = Readonly<{
-  workshop: Workshop;
-  cyclesToTarget: number;
-}>;
 
 export const getCurrentIncome = memoize((workshop: Workshop, clickBoost: number): number => {
   let totalIncome = 0;

--- a/test/buildWorkshop/runProgram.not.test.ts
+++ b/test/buildWorkshop/runProgram.not.test.ts
@@ -3,7 +3,6 @@ import {
   bottomUpToLastItem,
   bottomUpToMoney,
   fastestFamePerSecond,
-  productDownUpToMoney,
   quickestNewLevel,
 } from '../../src/buildWorkshop/computeIdealLevelsForEvent';
 import {
@@ -15,7 +14,7 @@ import {
 import { getStatusMap } from '../../src/buildWorkshop/helpers/WorkshopHelpers';
 import { printFameTime, printInfo, toTime } from '../../src/buildWorkshop/helpers/printResults';
 import { computeTargetFromFame, filterOutSkipped } from '../../src/buildWorkshop/helpers/targetHelpers';
-import { WorkshopUpgradeInfo } from '../../src/buildWorkshop/shouldUpgrade';
+import { WorkshopUpgradeInfo } from '../../src/buildWorkshop/productLooper';
 import {
   DEFAULT_WORKSHOP_STATUS_EVENT,
   DEFAULT_WORKSHOP_STATUS_MAIN,
@@ -154,17 +153,6 @@ describe.only('runProgram', () => {
 
         test('295 scientists', () => {
           testNumScientists(295);
-        });
-
-        test.skip('300 top down', () => {
-          const workshopStatus: WorkshopStatus = {
-            ...DEFAULT_WORKSHOP_STATUS_EVENT,
-            level: 10,
-            scientists: 293,
-            eventName: 'A Car is Born Click Last Three',
-          };
-          const target = getCostOfScientists(300);
-          printInfo(productDownUpToMoney(workshopStatus, target, 'Truck'), target);
         });
 
         test('300 scientists', () => {
@@ -450,8 +438,7 @@ describe.only('runProgram', () => {
         const workshopStatus: WorkshopStatus = { ...DEFAULT_WORKSHOP_STATUS_MAIN, ...partialWorkshopStatus };
         for (let amount = startingAmount; amount < 1000; amount++) {
           const targetInfo = bottomUpToMoney(getTarget(amount), workshopStatus);
-          const semiActiveTime = targetInfo.cyclesToTarget * 5;
-          if (semiActiveTime < targetTimeInSeconds) {
+          if (targetInfo.buildTime < targetTimeInSeconds) {
             withinTimeTargetInfo = targetInfo;
             withinTimeAmount = amount;
           } else break;
@@ -459,7 +446,7 @@ describe.only('runProgram', () => {
         if (withinTimeTargetInfo !== null) {
           console.log(filterOutSkipped(getStatusMap(withinTimeTargetInfo.workshop)));
           console.log('getting ' + withinTimeAmount.toString() + ' total ' + thingMaxing);
-          console.log('semi-active: ' + toTime(withinTimeTargetInfo.cyclesToTarget * 5));
+          console.log('idle: ' + toTime(withinTimeTargetInfo.buildTime));
           console.log(
             'research time minimum: ' + toTime(computeResearchTimeForWorkshop(withinTimeTargetInfo.workshop)),
           );
@@ -480,7 +467,7 @@ describe.only('runProgram', () => {
         }
       }
 
-      test('get as much fame as possible in semi-active 20 minutes at level 15', () => {
+      test('get as much fame as possible in idle 20 minutes at level 15', () => {
         const getTarget = (fame: number): number => computeTargetFromFame(fame, 15);
         maximizeTypeInTime('fame', 10, 5, { level: 15 }, getTarget);
       });
@@ -497,7 +484,7 @@ describe.only('runProgram', () => {
         );
       });
 
-      test('get as much fame as possible in semi-active 30 minutes at level 16', () => {
+      test('get as much fame as possible in idle 30 minutes at level 16', () => {
         const getTarget = (fame: number): number => computeTargetFromFame(fame, 16);
         maximizeTypeInTime('fame', 30, 5, { level: 16 }, getTarget);
       });
@@ -514,37 +501,37 @@ describe.only('runProgram', () => {
         );
       });
 
-      test('get as much fame as possible in semi-active 60 minutes at level 17', () => {
+      test('get as much fame as possible in idle 60 minutes at level 17', () => {
         const getTarget = (fame: number): number => computeTargetFromFame(fame, 17);
         maximizeTypeInTime('fame', 60, 12, { level: 17 }, getTarget);
       });
 
-      test('get as much fame as possible in semi-active 10 minutes at level 9', () => {
+      test('get as much fame as possible in idle 10 minutes at level 9', () => {
         const getTarget = (fame: number): number => computeTargetFromFame(fame, 9);
         maximizeTypeInTime('fame', 10, 8, { level: 9 }, getTarget);
       });
 
-      test('get as much fame as possible in semi-active 10 minutes at level 2', () => {
+      test('get as much fame as possible in idle 10 minutes at level 2', () => {
         const getTarget = (fame: number): number => computeTargetFromFame(fame, 2);
         maximizeTypeInTime('fame', 10, 0, { level: 2, scientists: 98 }, getTarget);
       });
 
-      test('get as much fame as possible in semi-active 10 minutes at level 3', () => {
+      test('get as much fame as possible in idle 10 minutes at level 3', () => {
         const getTarget = (fame: number): number => computeTargetFromFame(fame, 3);
         maximizeTypeInTime('fame', 10, 0, { level: 3, scientists: 150, researchBoostActive: true }, getTarget);
       });
 
-      test('get as much fame as possible in semi-active 5 minutes at level 3', () => {
+      test('get as much fame as possible in idle 5 minutes at level 3', () => {
         const getTarget = (fame: number): number => computeTargetFromFame(fame, 3);
         maximizeTypeInTime('fame', 5, 0, { level: 3, scientists: 150, researchBoostActive: true }, getTarget);
       });
 
-      test('get as much fame as possible in semi-active 5 minutes at level 4', () => {
+      test('get as much fame as possible in idle 5 minutes at level 4', () => {
         const getTarget = (fame: number): number => computeTargetFromFame(fame, 4);
         maximizeTypeInTime('fame', 5, 0, { level: 4, scientists: 150, researchBoostActive: true }, getTarget);
       });
 
-      test('get as much fame as possible in semi-active 5 minutes at level 5', () => {
+      test('get as much fame as possible in idle 5 minutes at level 5', () => {
         const getTarget = (fame: number): number => computeTargetFromFame(fame, 5);
         maximizeTypeInTime('fame', 5, 0, { level: 5, scientists: 173, researchBoostActive: true }, getTarget);
       });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,7 @@
     /* Language and Environment */
     "target": "es2017" /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */,
     "lib": [
-      "es2021"
+      "es2023"
     ] /* Specify a set of bundled library declaration files that describe the target runtime environment. */,
     // "jsx": "preserve",                                /* Specify what JSX code is generated. */
     // "experimentalDecorators": true,                   /* Enable experimental support for TC39 stage 2 draft decorators. */


### PR DESCRIPTION
Refactor to remove reporting on cyclesToTarget and instead use buildTime, which includes research time.

Also remove several unused functions in computeIdealLevels, rename several productLooper functions, get rid of `skipBuildIfUnderXCycles`, and use lib es2023 instead of 2021.

Fixes #18