### PR TITLE
Improve workshop optimization, esp around merchants

### DIFF
--- a/src/buildWorkshop/computeIdealLevelsForEvent.ts
+++ b/src/buildWorkshop/computeIdealLevelsForEvent.ts
@@ -128,7 +128,7 @@ function setUpProductsInfo(productDetails: ProductDetails[]): Product[] {
     productsInfo.push({
       status: {
         level: isFirstItem ? 1 : 0,
-        merchants: 0,
+        merchants: isFirstItem ? 1 : 0,
       },
       details,
     });

--- a/src/buildWorkshop/computeIdealLevelsForEvent.ts
+++ b/src/buildWorkshop/computeIdealLevelsForEvent.ts
@@ -28,12 +28,11 @@ export function quickestNewLevel(partialWorkshopStatus: Partial<WorkshopStatus>)
     const target = computeTargetFromFame(fame, workshopStatus.level);
     const targetInfo = bottomUpToMoney(target, workshopStatus);
     const idleBuildTime = computeBuildTimeForWorkshop(targetInfo.workshop, target);
-    // const researchTime = computeResearchTimeForWorkshop(targetInfo.workshop);
-    const finalTime = (idleBuildTime + 10) * Math.ceil(fameRequiredToLevelUp / fame);
-    if (finalTime > 60 * 45) {
+    if (idleBuildTime > 20 * 45) {
       console.log(`${fame} fame takes too long`);
       break;
     }
+    const finalTime = (idleBuildTime + 10) * Math.ceil(fameRequiredToLevelUp / fame);
     if (finalTime < bestTime) {
       bestTime = finalTime;
       bestFame = fame;

--- a/src/buildWorkshop/productLooper.ts
+++ b/src/buildWorkshop/productLooper.ts
@@ -66,7 +66,11 @@ function trimWorkshop(target: number, untrimmedWorkshop: Workshop, bestBuildTime
         ...bestWorkshop,
         productsInfo,
       };
-      const buildTime = computeBuildTimeForWorkshop(workshopWithProductRemoved, target, bestBuildTime);
+      const optimizedWorkshopWithProductRemoved = buildProductToNextProductOfWorkshop(
+        filterOutSkippedFullWorkshop(workshopWithProductRemoved),
+        target,
+      );
+      const buildTime = computeBuildTimeForWorkshop(optimizedWorkshopWithProductRemoved, target, bestBuildTime);
       if (buildTime <= bestBuildTime) {
         bestBuildTime = buildTime;
         bestWorkshop = workshopWithProductRemoved;

--- a/src/buildWorkshop/shouldUpgrade.ts
+++ b/src/buildWorkshop/shouldUpgrade.ts
@@ -17,7 +17,7 @@ export function getUpgradedWorkshopIfBetter(target: number, productName: string,
     : 1;
   const incomePerCycle = getCurrentIncome(workshop, clickBoost);
   const cyclesToTarget = target / incomePerCycle;
-  if (product.status.level === 0 && cyclesToTarget < 1) {
+  if (cyclesToTarget < 1) {
     return null;
   }
 

--- a/src/buildWorkshop/shouldUpgrade.ts
+++ b/src/buildWorkshop/shouldUpgrade.ts
@@ -66,7 +66,7 @@ function getCostToUpgradeProduct(product: Product, workshop: Workshop): UpgradeI
   let costToUpgradeProduct = 0;
   let modifiedWorkshop = workshop;
 
-  const parentUpgradeInfo: UpgradeInfo = upgradeSingleProduct(product, workshop);
+  const parentUpgradeInfo: UpgradeInfo = upgradeSingleProduct(product, workshop, true);
   costToUpgradeProduct += parentUpgradeInfo.costOfUpgrade;
   modifiedWorkshop = parentUpgradeInfo.workshop;
 
@@ -130,6 +130,7 @@ function upgradeInput(inputItemsNeeded: number, inputProductName: string, worksh
     const inputUpgradeInfo = upgradeSingleProduct(
       getProductByName(inputProductName, modifiedWorkshop.productsInfo),
       modifiedWorkshop,
+      false,
     );
     costToUpgradeInput += inputUpgradeInfo.costOfUpgrade;
     inputItems = ++inputLevel * inputProduct.details.outputCount;
@@ -151,18 +152,20 @@ type UpgradeInfo = Readonly<{
   costOfUpgrade: number;
 }>;
 
-function upgradeSingleProduct(product: Product, workshop: Workshop): UpgradeInfo {
+function upgradeSingleProduct(product: Product, workshop: Workshop, shouldUpdateMerchants: boolean): UpgradeInfo {
   const newStatus: ProductStatus = {
     ...product.status,
     level: product.status.level + 1,
-    merchants: Math.ceil(
-      ((product.status.level + 1) *
-        product.details.outputCount *
-        (workshop.workshopStatus.clickBoostActive ? CLICK_BOOST_MULTIPLIER * PROMOTION_BONUS_CLICK_OUTPUT : 1)) /
-        (isEvent(workshop.workshopStatus)
-          ? 10
-          : MAIN_WORKSHOP_MERCHANT_CAPACITY * PROMOTION_BONUS_MERCHANT_REVENUE_AND_CAPACITY),
-    ),
+    merchants: shouldUpdateMerchants
+      ? Math.ceil(
+          ((product.status.level + 1) *
+            product.details.outputCount *
+            (workshop.workshopStatus.clickBoostActive ? CLICK_BOOST_MULTIPLIER * PROMOTION_BONUS_CLICK_OUTPUT : 1)) /
+            (isEvent(workshop.workshopStatus)
+              ? 10
+              : MAIN_WORKSHOP_MERCHANT_CAPACITY * PROMOTION_BONUS_MERCHANT_REVENUE_AND_CAPACITY),
+        )
+      : product.status.merchants,
   };
   return {
     costOfUpgrade: product.details.buildCost * product.details.upgradeCostMultiplier ** product.status.level,


### PR DESCRIPTION
Previously merchants were calculated any time a product was leveled. Now they are only calculated when it is leveled as the main product, not as an input, so products only built to be inputs will have 0 merchants.

Also improve trimming algorithm to re-run building the whole thing without that product