### PR TITLE
#2: Only count products sold by merchants in income calculation

### DIFF
--- a/src/CLI/goals/auditMultipliers.ts
+++ b/src/CLI/goals/auditMultipliers.ts
@@ -14,6 +14,7 @@ import { isEvent } from '../../buildWorkshop/helpers/WorkshopHelpers';
 import {
   getMainWorkshopIncomeMultiplier,
   getMainWorkshopMerchantMultiplier,
+  getMerchantCapacity,
 } from '../../buildWorkshop/helpers/getWorkshopIncomeMultiplier';
 import { getSecondsPerCycle } from '../../buildWorkshop/helpers/targetHelpers';
 import {
@@ -61,7 +62,7 @@ function printMultipliers(partialWorkshopStatus: Partial<WorkshopStatus>): void 
       (workshopStatus.merchantBoostActive ? MERCHANT_BOOST_MULTIPLIER : 1) * getMainWorkshopMerchantMultiplier() * 100,
     )}%`,
   );
-  console.log(`Merchant Capacity: ${MAIN_WORKSHOP_MERCHANT_CAPACITY * PROMOTION_BONUS_MERCHANT_REVENUE_AND_CAPACITY}`);
+  console.log(`Merchant Capacity: ${getMerchantCapacity(workshopStatus)}`);
   console.log(`Speed: ${(10 / getSecondsPerCycle(workshopStatus.speedBoostActive)) * 100}%`);
 }
 

--- a/src/buildWorkshop/helpers/getWorkshopIncomeMultiplier.ts
+++ b/src/buildWorkshop/helpers/getWorkshopIncomeMultiplier.ts
@@ -14,7 +14,7 @@ import {
   MWS_EVENT_ACHIEVE_INCOME_MULTIPLIER,
   MWS_LOYALTY_ACHIEVE_MERCHANT_MULTIPLIER,
 } from '../constants/Achievements';
-import { Workshop, WorkshopStatus } from '../types/Workshop';
+import { WorkshopStatus } from '../types/Workshop';
 import { isEvent } from './WorkshopHelpers';
 
 export function getWorkshopIncomeMultiplier(workshopStatus: WorkshopStatus): number {
@@ -173,8 +173,6 @@ function getMWSLevelAchievementMultiplier(level: number): number {
   }
 }
 
-export function getMerchantCapacity(workshop: Workshop): number {
-  return isEvent(workshop.workshopStatus)
-    ? 10
-    : MAIN_WORKSHOP_MERCHANT_CAPACITY * PROMOTION_BONUS_MERCHANT_REVENUE_AND_CAPACITY;
+export function getMerchantCapacity(workshopStatus: WorkshopStatus): number {
+  return isEvent(workshopStatus) ? 10 : MAIN_WORKSHOP_MERCHANT_CAPACITY * PROMOTION_BONUS_MERCHANT_REVENUE_AND_CAPACITY;
 }

--- a/src/buildWorkshop/helpers/getWorkshopIncomeMultiplier.ts
+++ b/src/buildWorkshop/helpers/getWorkshopIncomeMultiplier.ts
@@ -7,12 +7,14 @@ import {
   MERCHANT_BOOST_MULTIPLIER,
   PROMOTION_BONUS_INCOME,
   PROMOTION_BONUS_MERCHANT_REVENUE,
+  PROMOTION_BONUS_MERCHANT_REVENUE_AND_CAPACITY,
 } from '../config/BoostMultipliers';
 import {
+  MAIN_WORKSHOP_MERCHANT_CAPACITY,
   MWS_EVENT_ACHIEVE_INCOME_MULTIPLIER,
   MWS_LOYALTY_ACHIEVE_MERCHANT_MULTIPLIER,
 } from '../constants/Achievements';
-import { WorkshopStatus } from '../types/Workshop';
+import { Workshop, WorkshopStatus } from '../types/Workshop';
 import { isEvent } from './WorkshopHelpers';
 
 export function getWorkshopIncomeMultiplier(workshopStatus: WorkshopStatus): number {
@@ -169,4 +171,10 @@ function getMWSLevelAchievementMultiplier(level: number): number {
     default:
       return 2.05e19;
   }
+}
+
+export function getMerchantCapacity(workshop: Workshop): number {
+  return isEvent(workshop.workshopStatus)
+    ? 10
+    : MAIN_WORKSHOP_MERCHANT_CAPACITY * PROMOTION_BONUS_MERCHANT_REVENUE_AND_CAPACITY;
 }

--- a/src/buildWorkshop/shouldUpgrade.ts
+++ b/src/buildWorkshop/shouldUpgrade.ts
@@ -30,7 +30,10 @@ export const getCurrentIncome = memoize((workshop: Workshop, clickBoost: number)
   // const topProduct: ProductDetails = getTopProduct(workshop);
   for (const product of workshop.productsInfo) {
     const numProductsMade = product.status.level * product.details.outputCount;
-    const maxProductsSold = Math.min(numProductsMade, product.status.merchants * getMerchantCapacity(workshop));
+    const maxProductsSold = Math.min(
+      numProductsMade,
+      product.status.merchants * getMerchantCapacity(workshop.workshopStatus),
+    );
     const numProductsConsumed = getInputItemsNeeded(product.details.name, workshop);
     const numProductsSold = Math.max(maxProductsSold - numProductsConsumed, 0);
     totalIncome +=
@@ -160,7 +163,7 @@ function upgradeSingleProduct(product: Product, workshop: Workshop, shouldUpdate
           ((product.status.level + 1) *
             product.details.outputCount *
             (workshop.workshopStatus.clickBoostActive ? CLICK_BOOST_MULTIPLIER * PROMOTION_BONUS_CLICK_OUTPUT : 1)) /
-            getMerchantCapacity(workshop),
+            getMerchantCapacity(workshop.workshopStatus),
         )
       : product.status.merchants,
   };


### PR DESCRIPTION
Income is now based on number of merchants and number of that product consumed as inputs to other products.

Fixes #2