### PR TITLE
34 Create goal of optimizing for lore gained per time

### DIFF
--- a/src/CLI/CLI.ts
+++ b/src/CLI/CLI.ts
@@ -7,6 +7,7 @@ import { doubleLoreGoal } from './goals/doubleLore';
 import { fastestFameGoal } from './goals/fastestFame';
 import { gemsGoal } from './goals/gems';
 import { levelUpGoal } from './goals/levelUp';
+import { mostLoreGoal } from './goals/lore';
 import { merchantsGoal } from './goals/merchants';
 import { scientistsGoal } from './goals/scientists';
 import { fameGoal } from './goals/specificFame';
@@ -27,6 +28,7 @@ const goals: Map<string, GoalType> = new Map<string, GoalType>([
   [merchantsGoal.name, merchantsGoal],
   [fameGoal.name, fameGoal],
   [fastestFameGoal.name, fastestFameGoal],
+  [mostLoreGoal.name, mostLoreGoal],
   [auditMultipliersGoal.name, auditMultipliersGoal],
 ]);
 
@@ -103,7 +105,7 @@ async function getWorkshopStatusFromUser(): Promise<Partial<WorkshopStatus>> {
   };
 }
 
-async function booleanChoice(message: string): Promise<boolean> {
+export async function booleanChoice(message: string): Promise<boolean> {
   return Boolean(
     await select({
       message,

--- a/src/CLI/goals/lore.ts
+++ b/src/CLI/goals/lore.ts
@@ -1,0 +1,20 @@
+import { lorePerSecond } from '../../buildWorkshop/computeIdealLevelsForEvent';
+import { isEvent } from '../../buildWorkshop/helpers/WorkshopHelpers';
+import { printInfo } from '../../buildWorkshop/helpers/printResults';
+import { WorkshopStatus } from '../../buildWorkshop/types/Workshop';
+import { GoalType, booleanChoice } from '../CLI';
+
+async function optimizeForLorePerTime(workshopStatus: Partial<WorkshopStatus>): Promise<void> {
+  const barHasToken = await booleanChoice('is there a blueprint token or pack in the "easy" slot?');
+  const targetInfo = lorePerSecond(workshopStatus, barHasToken);
+  printInfo(targetInfo);
+}
+
+export const mostLoreGoal: GoalType = {
+  name: 'most lore',
+  description: 'most efficient lore over time',
+  shouldShow: (workshopStatus: WorkshopStatus) => !isEvent(workshopStatus),
+  selectOptionAndGetInput: async (workshopStatus: WorkshopStatus) => {
+    await optimizeForLorePerTime(workshopStatus);
+  },
+};

--- a/src/buildWorkshop/config/BoostMultipliers.ts
+++ b/src/buildWorkshop/config/BoostMultipliers.ts
@@ -15,3 +15,5 @@ export const PROMOTION_BONUS_RESEARCH = 1;
 export const PROMOTION_BONUS_CLICK_OUTPUT = 1;
 export const PROMOTION_BONUS_SPEED = 1;
 export const PROMOTION_BONUS_LPP = 0;
+
+export const LPP = 64;


### PR DESCRIPTION
Add a goal to maximize amount of lore over time, accounting for single and double and if there's a token taking up some of the lore space.

Fixes #34
