### PR TITLE
#7: Account for click bonus for quantities of products needed at the top

### DIFF
--- a/src/CLI/CLI.ts
+++ b/src/CLI/CLI.ts
@@ -11,6 +11,7 @@ import { mostLoreGoal } from './goals/lore';
 import { merchantsGoal } from './goals/merchants';
 import { scientistsGoal } from './goals/scientists';
 import { fameGoal } from './goals/specificFame';
+import { clickTopInputsGoal } from './goals/clickTopAndInputs';
 
 export type GoalType = Readonly<{
   name: string;
@@ -28,6 +29,7 @@ const goals: Map<string, GoalType> = new Map<string, GoalType>([
   [merchantsGoal.name, merchantsGoal],
   [fameGoal.name, fameGoal],
   [fastestFameGoal.name, fastestFameGoal],
+  [clickTopInputsGoal.name, clickTopInputsGoal],
   [mostLoreGoal.name, mostLoreGoal],
   [auditMultipliersGoal.name, auditMultipliersGoal],
 ]);

--- a/src/CLI/goals/clickTopAndInputs.ts
+++ b/src/CLI/goals/clickTopAndInputs.ts
@@ -1,0 +1,26 @@
+import { input } from '@inquirer/prompts';
+import { clickTopAndInputs } from '../../buildWorkshop/computeIdealLevelsForEvent';
+import { getCostOfScientistsFromSome } from '../../buildWorkshop/helpers/ResearchHelpers';
+import { isEvent } from '../../buildWorkshop/helpers/WorkshopHelpers';
+import { printInfo } from '../../buildWorkshop/helpers/printResults';
+import { DEFAULT_WORKSHOP_STATUS_EVENT, WorkshopStatus } from '../../buildWorkshop/types/Workshop';
+import { GoalType } from '../CLI';
+
+async function optimizeForClickingTopAndItsInputs(partialWorkshopStatus: Partial<WorkshopStatus>): Promise<void> {
+  const workshopStatus: WorkshopStatus = { ...DEFAULT_WORKSHOP_STATUS_EVENT, ...partialWorkshopStatus };
+  const desiredScientists = await input({
+    message: 'how many scientists do you want?',
+  });
+  const target = getCostOfScientistsFromSome(workshopStatus.scientists ?? 0, Number(desiredScientists));
+  const targetInfo = clickTopAndInputs(target, workshopStatus);
+  printInfo(targetInfo, target);
+}
+
+export const clickTopInputsGoal: GoalType = {
+  name: 'click top product and its inputs',
+  description: 'helpful on level 10 of events: account for click bonus and extra speed of clicks',
+  shouldShow: (workshopStatus: WorkshopStatus) => isEvent(workshopStatus),
+  selectOptionAndGetInput: async (workshopStatus: WorkshopStatus) => {
+    await optimizeForClickingTopAndItsInputs(workshopStatus);
+  },
+};


### PR DESCRIPTION
When choosing this option, it is assumed that the top product and its up to two inputs are being clicked every 150ms or so, making 3.5x as many cycles as would be typical, so it adjusts the required inputs by that quantity. It is also assumed that the click boost is active, so adjusts the outputs by that quantity. Autoclickers FTW.

Fixes #7.