### PR TITLE
#8: Handle premium income boost

### DIFF
--- a/src/buildWorkshop/config/BoostMultipliers.ts
+++ b/src/buildWorkshop/config/BoostMultipliers.ts
@@ -7,6 +7,8 @@ export const DAILY_DYNASTY_FRIEND_BONUS_INCOME = 30;
 export const DAILY_DYNASTY_FRIEND_BONUS_ORE = 10;
 export const DAILY_DYNASTY_FRIEND_BONUS_MERCHANT = 30;
 
+// during events, regular income is affected but offline is not. income&offline is the permanent, the other is only during 24hr events
+export const PROMOTION_BONUS_INCOME_AND_OFFLINE = 1;
 export const PROMOTION_BONUS_INCOME = 1;
 // during events, revenue is affected but capacity is not. rev&cap is the permanent, the other is only during 24hr events
 export const PROMOTION_BONUS_MERCHANT_REVENUE_AND_CAPACITY = 1;

--- a/src/buildWorkshop/helpers/otherMultiplierHelpers.ts
+++ b/src/buildWorkshop/helpers/otherMultiplierHelpers.ts
@@ -4,7 +4,7 @@ import {
   CLICK_BOOST_MULTIPLIER,
   DAILY_DYNASTY_FRIEND_BONUS_ORE,
   PROMOTION_BONUS_CLICK_OUTPUT,
-  PROMOTION_BONUS_INCOME,
+  PROMOTION_BONUS_INCOME_AND_OFFLINE,
 } from '../config/BoostMultipliers';
 import { MWS_MONEY_ACHIEVE_OFFLINE_MULTIPLIER } from '../constants/Achievements';
 import { WorkshopStatus } from '../types/Workshop';
@@ -29,5 +29,5 @@ export function getOfflineMultiplier(isEvent: boolean): number {
     : 40 *
         MWS_MONEY_ACHIEVE_OFFLINE_MULTIPLIER *
         getSpecifiedMultiplierFromLibrary(SetMultiplierType.OfflineProduction) *
-        PROMOTION_BONUS_INCOME;
+        PROMOTION_BONUS_INCOME_AND_OFFLINE;
 }


### PR DESCRIPTION
During premium income events, income is affected but offline income is not. Account for this.

Related to #8